### PR TITLE
Fix: Make file item clickable by moving onclick to parent div

### DIFF
--- a/templates/file_item.html
+++ b/templates/file_item.html
@@ -1,6 +1,6 @@
 <li class="nav-item" id="file-item-{{ file.id }}">
-    <div class="d-flex justify-content-between align-items-center file-item">
-        <a class="nav-link" href="#" onclick="viewPdf('{{ url_for('uploaded_file', filename=file.filename) }}', {{ file.id }}, {{ file.filename|tojson }})">
+    <div class="d-flex justify-content-between align-items-center file-item" onclick="viewPdf('{{ url_for('uploaded_file', filename=file.filename) }}', {{ file.id }}, {{ file.filename|tojson }})" style="cursor: pointer;">
+        <a class="nav-link" href="#">
             <i class="bi bi-file-earmark-text me-2"></i>
             <span>{{ file.filename }}</span>
         </a>


### PR DESCRIPTION
The file item was not clickable because the onclick handler was on the `<a>` tag, which may have been obscured or had its events intercepted. This change moves the `onclick` handler to the parent `div` and adds `cursor: pointer` to make the entire row clickable, which is a more robust solution and a better user experience.