### PR TITLE
feat: Add voice sample playback

### DIFF
--- a/app.py
+++ b/app.py
@@ -595,9 +595,12 @@ def play_voice_sample():
             settings = get_settings()
             tts_model_name = f"models/{settings.tts_model}"
 
-            audio_data = generate_voice_sample(app.gemini_client, tts_model_name, voice, sample_text)
+            audio_data, mime_type = generate_voice_sample(app.gemini_client, tts_model_name, voice, sample_text)
 
-            audio = AudioSegment(data=audio_data, sample_width=2, frame_rate=24000, channels=1)
+            match = re.search(r'rate=(\d+)', mime_type)
+            sample_rate = int(match.group(1)) if match else 24000
+
+            audio = AudioSegment(data=audio_data, sample_width=2, frame_rate=sample_rate, channels=1)
             audio.export(mp3_filepath, format="mp3")
             app.logger.info(f"Saved voice sample to {mp3_filepath}")
 

--- a/services.py
+++ b/services.py
@@ -155,3 +155,24 @@ def process_pdf(filepath):
 
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in {'pdf'}
+
+def generate_voice_sample(client, model_name, voice_name, text):
+    """
+    Generates a voice sample using the specified voice.
+    """
+    tts_config = types.GenerateContentConfig(
+        response_modalities=["AUDIO"],
+        speech_config=types.SpeechConfig(
+            voice_config=types.VoiceConfig(
+                prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=voice_name)
+            )
+        )
+    )
+
+    # The prompt for single-voice TTS is just the text itself.
+    tts_response = client.models.generate_content(
+        model=model_name, contents=[text], config=tts_config
+    )
+
+    audio_part = tts_response.candidates[0].content.parts[0]
+    return audio_part.inline_data.data

--- a/services.py
+++ b/services.py
@@ -159,6 +159,7 @@ def allowed_file(filename):
 def generate_voice_sample(client, model_name, voice_name, text):
     """
     Generates a voice sample using the specified voice.
+    Returns a tuple of (audio_data, mime_type).
     """
     tts_config = types.GenerateContentConfig(
         response_modalities=["AUDIO"],
@@ -175,4 +176,4 @@ def generate_voice_sample(client, model_name, voice_name, text):
     )
 
     audio_part = tts_response.candidates[0].content.parts[0]
-    return audio_part.inline_data.data
+    return audio_part.inline_data.data, audio_part.inline_data.mime_type

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -697,7 +697,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (document.querySelector('body.settings-page')) {
         const playButtons = document.querySelectorAll('.play-sample-button');
         let currentAudio = null;
-        let originalButtonIcon = null;
 
         playButtons.forEach(button => {
             button.addEventListener('click', () => {
@@ -705,15 +704,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 const select = document.getElementById(targetId);
                 const voice = select.value;
                 const icon = button.querySelector('i');
-                originalButtonIcon = icon.className;
+                const playIconClass = 'bi bi-volume-up-fill';
 
                 // Stop any currently playing audio
                 if (currentAudio && !currentAudio.paused) {
                     currentAudio.pause();
                     currentAudio.currentTime = 0;
-                     const previousButton = document.querySelector('.playing');
-                    if(previousButton) {
-                        previousButton.querySelector('i').className = originalButtonIcon;
+                    const previousButton = document.querySelector('.playing');
+                    if (previousButton) {
+                        previousButton.querySelector('i').className = playIconClass;
                         previousButton.classList.remove('playing');
                     }
                 }
@@ -721,7 +720,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 // If clicking the same button that is playing, just stop it.
                 if (button.classList.contains('playing')) {
                     button.classList.remove('playing');
-                    icon.className = originalButtonIcon;
+                    icon.className = playIconClass;
                     currentAudio = null;
                     return;
                 }
@@ -752,14 +751,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     currentAudio.addEventListener('ended', () => {
                         button.classList.remove('playing');
-                        icon.className = originalButtonIcon;
+                        icon.className = playIconClass;
                         currentAudio = null;
                     });
                 })
                 .catch(error => {
                     console.error('Error playing voice sample:', error);
                     alert('Failed to play voice sample. See console for details.');
-                    icon.className = originalButtonIcon;
+                    icon.className = playIconClass;
                     button.disabled = false;
                 });
             });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -695,72 +695,76 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Settings Page Specific Logic ---
     if (document.querySelector('body.settings-page')) {
-        const playButtons = document.querySelectorAll('.play-sample-button');
         let currentAudio = null;
+        const playIconClass = 'bi bi-volume-up-fill';
+        const stopIconClass = 'bi bi-stop-circle-fill';
+        const loadingIconClass = 'spinner-border spinner-border-sm';
 
+        function stopCurrentSample() {
+            if (currentAudio) {
+                currentAudio.pause();
+                currentAudio.currentTime = 0;
+            }
+            const previousButton = document.querySelector('.playing');
+            if (previousButton) {
+                resetButtonState(previousButton);
+            }
+            currentAudio = null;
+        }
+
+        function resetButtonState(button) {
+            button.classList.remove('playing');
+            button.querySelector('i').className = playIconClass;
+            button.disabled = false;
+        }
+
+        function playSample(button, voice) {
+            const icon = button.querySelector('i');
+            icon.className = loadingIconClass;
+            button.disabled = true;
+
+            fetch('/play_voice_sample', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ voice: voice }),
+            })
+            .then(response => {
+                if (!response.ok) throw new Error('Network response was not ok');
+                return response.json();
+            })
+            .then(data => {
+                currentAudio = new Audio(data.audio_url);
+                button.classList.add('playing');
+                icon.className = stopIconClass;
+                button.disabled = false;
+
+                currentAudio.play();
+
+                currentAudio.addEventListener('ended', () => {
+                    resetButtonState(button);
+                    currentAudio = null;
+                });
+            })
+            .catch(error => {
+                console.error('Error playing voice sample:', error);
+                alert('Failed to play voice sample. See console for details.');
+                resetButtonState(button);
+            });
+        }
+
+        const playButtons = document.querySelectorAll('.play-sample-button');
         playButtons.forEach(button => {
             button.addEventListener('click', () => {
-                const targetId = button.dataset.targetSelect;
-                const select = document.getElementById(targetId);
-                const voice = select.value;
-                const icon = button.querySelector('i');
-                const playIconClass = 'bi bi-volume-up-fill';
+                const wasPlaying = button.classList.contains('playing');
 
-                // Stop any currently playing audio
-                if (currentAudio && !currentAudio.paused) {
-                    currentAudio.pause();
-                    currentAudio.currentTime = 0;
-                    const previousButton = document.querySelector('.playing');
-                    if (previousButton) {
-                        previousButton.querySelector('i').className = playIconClass;
-                        previousButton.classList.remove('playing');
-                    }
+                stopCurrentSample();
+
+                if (!wasPlaying) {
+                    const targetId = button.dataset.targetSelect;
+                    const select = document.getElementById(targetId);
+                    const voice = select.value;
+                    playSample(button, voice);
                 }
-
-                // If clicking the same button that is playing, just stop it.
-                if (button.classList.contains('playing')) {
-                    button.classList.remove('playing');
-                    icon.className = playIconClass;
-                    currentAudio = null;
-                    return;
-                }
-
-                icon.className = 'spinner-border spinner-border-sm';
-                button.disabled = true;
-
-                fetch('/play_voice_sample', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({ voice: voice }),
-                })
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error('Network response was not ok');
-                    }
-                    return response.json();
-                })
-                .then(data => {
-                    currentAudio = new Audio(data.audio_url);
-                    button.classList.add('playing');
-                    icon.className = 'bi bi-stop-circle-fill'; // Change to stop icon
-                    button.disabled = false;
-
-                    currentAudio.play();
-
-                    currentAudio.addEventListener('ended', () => {
-                        button.classList.remove('playing');
-                        icon.className = playIconClass;
-                        currentAudio = null;
-                    });
-                })
-                .catch(error => {
-                    console.error('Error playing voice sample:', error);
-                    alert('Failed to play voice sample. See console for details.');
-                    icon.className = playIconClass;
-                    button.disabled = false;
-                });
             });
         });
     }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -7,7 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
-<body>
+<body class="settings-page">
     <div class="container mt-5">
         <div class="row">
             <div class="col-md-8 offset-md-2">
@@ -68,19 +68,29 @@
                             <h3>Text-to-Speech Voices</h3>
                             <div class="mb-3">
                                 <label for="tts_host_voice" class="form-label">Host Voice</label>
-                                <select class="form-select" id="tts_host_voice" name="tts_host_voice">
-                                    {% for voice in voices %}
-                                        <option value="{{ voice }}" {% if voice == settings.tts_host_voice %}selected{% endif %}>{{ voice }}</option>
-                                    {% endfor %}
-                                </select>
+                                <div class="input-group">
+                                    <select class="form-select" id="tts_host_voice" name="tts_host_voice">
+                                        {% for voice in voices %}
+                                            <option value="{{ voice }}" {% if voice == settings.tts_host_voice %}selected{% endif %}>{{ voice }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    <button class="btn btn-outline-secondary play-sample-button" type="button" data-target-select="tts_host_voice">
+                                        <i class="bi bi-volume-up-fill"></i>
+                                    </button>
+                                </div>
                             </div>
                             <div class="mb-3">
                                 <label for="tts_expert_voice" class="form-label">Expert Voice</label>
-                                <select class="form-select" id="tts_expert_voice" name="tts_expert_voice">
-                                    {% for voice in voices %}
-                                        <option value="{{ voice }}" {% if voice == settings.tts_expert_voice %}selected{% endif %}>{{ voice }}</option>
-                                    {% endfor %}
-                                </select>
+                                <div class="input-group">
+                                    <select class="form-select" id="tts_expert_voice" name="tts_expert_voice">
+                                        {% for voice in voices %}
+                                            <option value="{{ voice }}" {% if voice == settings.tts_expert_voice %}selected{% endif %}>{{ voice }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    <button class="btn btn-outline-secondary play-sample-button" type="button" data-target-select="tts_expert_voice">
+                                        <i class="bi bi-volume-up-fill"></i>
+                                    </button>
+                                </div>
                             </div>
                             <button type="submit" class="btn btn-primary">Save Settings</button>
                             <a href="{{ url_for('index') }}" class="btn btn-secondary">Back to Home</a>


### PR DESCRIPTION
This commit introduces a new feature that allows users to listen to a sample of the available Text-to-Speech voices directly from the settings page.

Key changes:
- A speaker button has been added next to each voice selector in `templates/settings.html`.
- The frontend JavaScript in `static/js/main.js` has been updated to handle clicks on these buttons. It now makes an API call to a new endpoint to fetch and play the audio sample.
- A new route, `/play_voice_sample`, has been added to `app.py`. This endpoint is responsible for generating and serving the voice samples. It includes caching by saving the generated samples to a `generated_audio/samples` directory.
- A new function, `generate_voice_sample`, has been added to `services.py` to encapsulate the logic for generating a single voice sample using the Gemini API.